### PR TITLE
Use json if simplejson is unavailable.

### DIFF
--- a/ZabbixSender/ZabbixSender.py
+++ b/ZabbixSender/ZabbixSender.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 import socket
 import struct
-import simplejson
+try:
+    import simplejson
+except ImportError:
+    import json as simplejson
 
 class ZabbixSender:
 	


### PR DESCRIPTION
Python 2.7.6 and later ships simplejson no longer.
